### PR TITLE
v0.4.1

### DIFF
--- a/cmd/goCBC/main.go
+++ b/cmd/goCBC/main.go
@@ -118,7 +118,7 @@ func runApp(args []string) {
 	slog.Info("Finished RunHLCalculations", "results", (&results).String())
 
 	// Generate and print output
-	fmt.Println(progutils.GenerateOutputTableV1(&results, &wearoffTarget, &(*chemPointer).Name))
+	fmt.Println(progutils.GenerateOutputTableV1(&results, &wearoffTarget, chemPointer))
 }
 
 func initLogging() {

--- a/pkg/chems/00_chems.go
+++ b/pkg/chems/00_chems.go
@@ -25,6 +25,7 @@ type Chem struct {
 	Name         string
 	Halflife     float64
 	Description  string
+	StandardUnit string
 	CommonValues string
 }
 

--- a/pkg/chems/caffeine.go
+++ b/pkg/chems/caffeine.go
@@ -22,6 +22,7 @@ var Caffeine = Chem{
 	Name:         "caffeine",
 	Halflife:     5.00,
 	Description:  "unused",
+	StandardUnit: "mg",
 	CommonValues: caffeineCommonValuesTable,
 }
 var caffeineCommonValuesTable = `

--- a/pkg/chems/nicotine.go
+++ b/pkg/chems/nicotine.go
@@ -22,6 +22,7 @@ var Nicotine = Chem{
 	Name:         "nicotine",
 	Halflife:     4.25,
 	Description:  "unused",
+	StandardUnit: "mg",
 	CommonValues: nicotineCommonValuesTable,
 }
 var nicotineCommonValuesTable = `

--- a/pkg/progmeta/progmeta.go
+++ b/pkg/progmeta/progmeta.go
@@ -50,7 +50,7 @@ var (
 	ProgVersion = Version{
 		Major:    "0",
 		Minor:    "4",
-		Patch:    "0",
+		Patch:    "1",
 		Build:    build,
 		Runtime:  runtime.Version(),
 		Platform: getPlatform(),

--- a/pkg/progutils/outputgeneration.go
+++ b/pkg/progutils/outputgeneration.go
@@ -32,18 +32,19 @@ import (
 
 // GenerateOutputTableV1 creates a formatted table displaying current substance levels
 // and anticipated wearoff time based on the target amount.
-func GenerateOutputTableV1(r *Results, wearoffTarget *string, chem *string) *table.Table {
-	slog.Debug("Generating output table", "wearoffTarget", *wearoffTarget, "chem", *chem, "results", (*r).String())
+func GenerateOutputTableV1(r *Results, wearoffTarget *string, chemPtr *chems.Chem) *table.Table {
+	slog.Debug("Generating output table", "wearoffTarget", *wearoffTarget, "chem", (*chemPtr).Name, "results", (*r).String())
 	rows := [][]string{
 		{
 			fmt.Sprintf(
 				"%s remaining in system:",
-				Styles.Chem.Render(StringToTitleCase(*chem)),
+				Styles.Chem.Render(StringToTitleCase((*chemPtr).Name)),
 			),
 			Styles.Chem.Render(
 				fmt.Sprintf(
-					"~%.0fmg",
+					"~%.0f%s",
 					math.Round((*r).BodyChemContent),
+					(*chemPtr).StandardUnit,
 				),
 			),
 		},
@@ -51,7 +52,7 @@ func GenerateOutputTableV1(r *Results, wearoffTarget *string, chem *string) *tab
 			fmt.Sprintf(
 				"Reach target (%s) for %s at:",
 				Styles.Chem.Render(
-					fmt.Sprintf("%smg", *wearoffTarget),
+					fmt.Sprintf("%s%s", *wearoffTarget, (*chemPtr).StandardUnit),
 				),
 				Styles.Wearoff.Render("wear-off"),
 			),
@@ -65,12 +66,13 @@ func GenerateOutputTableV1(r *Results, wearoffTarget *string, chem *string) *tab
 			[]string{
 				fmt.Sprintf(
 					"Future %s intake total:",
-					Styles.Chem.Render(*chem),
+					Styles.Chem.Render((*chemPtr).Name),
 				),
 				Styles.Chem.Render(
 					fmt.Sprintf(
-						"%.0fmg",
+						"%.0f%s",
 						math.Round((*r).TheoreticalChemIngestedTotal),
+						(*chemPtr).StandardUnit,
 					),
 				),
 			},
@@ -81,7 +83,7 @@ func GenerateOutputTableV1(r *Results, wearoffTarget *string, chem *string) *tab
 					"With future intake reach %s target (%s) at:",
 					Styles.Wearoff.Render("wear-off"),
 					Styles.Chem.Render(
-						fmt.Sprintf("%smg", *wearoffTarget),
+						fmt.Sprintf("%s%s", *wearoffTarget, (*chemPtr).StandardUnit),
 					),
 				),
 				Styles.Wearoff.Render(
@@ -123,7 +125,7 @@ func ShowCommon(chemPointer *chems.Chem) {
 		(*chemPointer).Name,
 		(*chemPointer).CommonValues,
 	)
-	
+
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
 	)
@@ -158,7 +160,6 @@ func genChemOutputTable() *table.Table {
 		rows = append(rows, []string{chemName, fmt.Sprintf("%.2f hours", (*chemPointer).Halflife)})
 	}
 
-	//chemTable := table.New().Border(lipgloss.HiddenBorder()).BorderHeader(true).Rows(rows...).Headers(header...)
 	chemTable := table.New().
 		Headers(header...).Rows(rows...).
 		StyleFunc(func(row, col int) lipgloss.Style {
@@ -174,13 +175,7 @@ func genChemOutputTable() *table.Table {
 				//	return progutils.Styles.TableOddRow
 			}
 		}).
-		BorderHeader(false).
-		BorderColumn(false).
-		BorderRow(false).
-		BorderLeft(false).
-		BorderRight(false).
-		BorderTop(false).
-		BorderBottom(false)
+		Border(lipgloss.HiddenBorder())
 
 	return chemTable
 }


### PR DESCRIPTION
## Feature Enhancement: Chemical Unit Standardization and Output Formatting

### Changes
- Added `StandardUnit` field to `Chem` struct in `pkg/chems/00_chems.go`
- Updated caffeine and nicotine chemical definitions to include `StandardUnit: "mg"`
- Modified `GenerateOutputTableV1` to dynamically use chemical-specific standard units
- Updated function signature to accept `*chems.Chem` instead of chemical name string
- Simplified table rendering in chemical list view
- Incremented patch version to 0.4.1

### Improvements
- Standardizes unit display for different chemicals
- Increases flexibility for future chemical additions
- Improves type safety by passing chemical pointer
- Enhances output formatting with dynamic unit handling

### Impact
- No breaking changes to existing functionality
- Prepares codebase for potential future chemical additions
- Improves code readability and maintainability

### Testing
- Verified output formatting with existing chemical types
- Ensured compatibility with current calculation methods

🔬 Generated with Crush