### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,5 +1,8 @@
 name: Makefile CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/sethll/goCBC/security/code-scanning/1](https://github.com/sethll/goCBC/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions:` block near the top of the workflow file to restrict the GITHUB_TOKEN's permissions to the least privilege necessary for the jobs. For simple CI workflows that only check out code, run tests, and upload artifacts, `contents: read` is usually sufficient. The block should be added at the root of the workflow (before `jobs:`) so that it affects all jobs unless overridden. This does not meaningfully alter existing functionality and safely limits CI automation risk.

Specific steps:
- Edit `.github/workflows/makefile.yml`
- Add the following block under the workflow `name:` and before the `on:` block:

```yaml
permissions:
  contents: read
```
No imports or further definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
